### PR TITLE
Fixing empty anchors

### DIFF
--- a/src/main/java/it/cnr/isti/hpc/wikipedia/article/Link.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/article/Link.java
@@ -37,7 +37,7 @@ public class Link {
 	public Link(String id, String description) {
 		super();
 		this.id = id;
-		this.description = description;
+		setDescription(description);
 	}
 	
 	public String getId() {
@@ -51,16 +51,18 @@ public class Link {
 	
 	
 	public String getDescription() {
-		// When description is empty, it means is the same of id
-		if (description != null && !description.isEmpty())
-			return description;
-		else
-			return id;
+		return this.description;
 	}
 	
 	
 	public void setDescription(String description) {
-		this.description = description;
+        // Some links do not have any anchor
+        // For those cases the anchor is the same wikipedia Id
+		if (description.isEmpty()){
+            this.description = this.id.replace("_", " ");
+        }else{
+            this.description = description;
+        }
 	}
 
 	/**  

--- a/src/test/java/it/cnr/isti/hpc/wikipedia/article/en/ArticleTest.java
+++ b/src/test/java/it/cnr/isti/hpc/wikipedia/article/en/ArticleTest.java
@@ -17,9 +17,11 @@ package it.cnr.isti.hpc.wikipedia.article.en;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import it.cnr.isti.hpc.io.IOUtils;
 import it.cnr.isti.hpc.wikipedia.article.Article;
 import it.cnr.isti.hpc.wikipedia.article.Language;
+import it.cnr.isti.hpc.wikipedia.article.Link;
 import it.cnr.isti.hpc.wikipedia.parser.ArticleParser;
 
 import java.io.IOException;
@@ -82,6 +84,26 @@ public class ArticleTest {
 		
 		
 	}
+
+    @Test
+    public void testNoEmptyAnchors() throws IOException {
+        Article a = new Article();
+        String mediawiki = IOUtils.getFileAsUTF8String("./src/test/resources/en/Royal_Thai_Armed_Forces.txt");
+        parser.parse(a, mediawiki);
+
+        // No anchor should be empty
+        for (Link link:a.getLinks()){
+            assertFalse(link.getDescription().isEmpty());
+        }
+
+        // testing an specific anchor
+        for (Link link:a.getLinks()){
+            if (link.getId().equals("HTMS_Chakri_Naruebet"))
+                assertEquals(link.getDescription(),"HTMS Chakri Naruebet");
+        }
+
+
+    }
 	
 	
 	

--- a/src/test/resources/en/Royal_Thai_Armed_Forces.txt
+++ b/src/test/resources/en/Royal_Thai_Armed_Forces.txt
@@ -1,0 +1,220 @@
+{{Infobox national military
+|country            = Thailand
+|name               = Royal Thai Armed Forces
+|native_name        = กองทัพไทย
+|image              = [[image:Emblem of the Royal Thai Armed Forces HQ.svg|200px]]
+|caption            = Emblem of the '''[[Royal Thai Armed Forces Headquarters]]'''
+|image2             =
+|caption2           =
+|founded            = 1852
+|current_form       =
+|disbanded          =
+|branches           =[[Image:Royal Thai Army Flag.svg|40px]] '''[[Royal Thai Army]]'''<br>[[Image:Royal Thai Navy Flag.svg|40px]] '''[[Royal Thai Navy]]'''<br>[[Image:Royal Thai Air Force Flag.svg|40px]] '''[[Royal Thai Air Force]]'''
+|headquarters       =
+|flying_hours       =
+<!-- Leadership -->
+|commander-in-chief = King [[Bhumibol Adulyadej]]
+|commander-in-chief_title = [[Commander-in-chief of the Royal Thai Armed Forces|Commander-in-Chief]]
+|minister           = General Prawit Wongsuwan
+|minister_title     = [[Ministry of Defence (Thailand)|Minister of Defence]]
+|commander          = General [[Worapong Sanganetra]]
+|commander_title    = [[List of Commanders of the Royal Thai Armed Forces Headquarters|Chief of Defence Forces]]
+<!-- Manpower -->
+|age                = 21–49
+|conscription       = 21 years of age
+|manpower_data      = 1,043,204 (2013) <ref name="GF Mil Age">{{cite web|title=Manpower Reaching Military Age Annually |url=http://www.globalfirepower.com/manpower-reaching-military-age-annually.asp | website=Global Firepower | publisher=Global Firepower | accessdate=2014-10-16}}</ref>
+|manpower_age       =
+|active             = 306,000
+|ranked             =
+|reserve            = 245,000
+|deployed           =
+<!-- Financial -->
+|amount             = [[Fiscal year|FY]] 2014 – [[List of countries by military expenditures|ranked 35th]]<br>[[US Dollars|USD]] 5.7 billion<ref>{{cite web |url=http://defense-studies.blogspot.com/2014/07/thailand-raises-defence-budget-5.html |title=Thailand Raises Defence Budget 5% |date=July 17, 2014}}</ref>
+|percent_GDP=1.5% (2012 est.)
+<!-- Industrial -->
+|domestic_foreign   =
+|domestic_suppliers = [[Thai Aviation Industry]]<br>[[Chaiseri Metal & Rubber]]<br>[[Defense Technology Institute]]<br>[[Avia Satcom]]<br>[[Bangkok Dock]]<br>[[G-Force Composite]]<br>[[Italthai Marine]]<br>[[Marsun Shipbuilding]]<br>[[Military Explosives Factory]]<br>[[Naval Aircraft Experimental]]<br>[[Mahidol Adulyadej Naval Dockyard]]<br>[[Thai Rung Union Car]]
+|foreign_suppliers  = {{flag|United States}}<br>{{flag|China}}<br>{{flag|Israel}}<br>{{flag|Sweden}}<br>{{flag|Russia}}<br>{{flag|Ukraine}}<br>{{flag|Spain}}<br>{{flag|Germany}}<br>{{flag|Canada}}<br>{{flag|Australia}}<br>{{flag|Czech Republic}}<br>{{flag|Italy}}<br>{{flag|Brazil}}<br>{{flag|Switzerland}}<br>{{flag|Belgium}}<br>{{flag|South Africa}}<br>{{flag|Mexico}}<br>{{flag|South Korea}}<br>{{flag|Austria}}<br>{{flag|Pakistan}}<br>{{flag|France}}<br>{{flag|United Kingdom}}
+|imports            = {{flag|Singapore}}
+|exports            =
+<!-- Related aricles -->
+|history            =[[Military history of Thailand]]
+|ranks              =[[Military ranks of the Thai armed forces|Military ranks of Thailand]]
+}}
+
+The '''Royal Thai Armed Forces''' ({{lang-th|กองทัพไทย}}; {{RTGS|Kong Thap Thai}}) is the name of the [[military]] of the [[Kingdom of Thailand]]. It consists of the following branches:
+* '''[[Royal Thai Army]]''' (กองทัพบกไทย)
+* '''[[Royal Thai Navy]]''' (กองทัพเรือไทย, ราชนาวีไทย)
+**[[Royal Thai Marine Corps]] (นาวิกโยธินไทย)
+* '''[[Royal Thai Air Force]]''' (กองทัพอากาศไทย)
+*Other [[Paramilitary]] Forces
+
+Created in 1852, the Royal Thai Armed Forces came into existence as permanent force at the behest of King [[Mongkut]], who needed a [[Europe]]an trained military force in order to thwart any western threat and any attempts at colonialization. By 1887, during the next reign of King [[Chulalongkorn]], a permanent military command in the [[Kalahom|''Kalahom'' Department]] was established. However the office of ''Kalahom'' and the military of Siam had existed since the days of the [[Sukhothai Kingdom]] in the 13th Century.<ref>[http://web.archive.org/web/20080624075931/http://aarm2007.rta.mi.th/history_royal_th.htm The Royal Thai Army. Brief History]. rta.mi.th</ref> In fact the history of the [[Kings of Siam]] is teeming with tales of military conquest and power.<ref>[http://www.globalsecurity.org/military/world/thailand/mil-history.htm Military History]. www.globalsecurity.org. Retrieved on 2012-01-18.</ref> However, since 1932, when the military, with the help of civilians, decided to [[Siamese Revolution of 1932|overthrow]] the system of [[absolute monarchy]] and instead created a [[constitutional monarchy|constitutional]] system, the military has dominated and been in control of [[Politics of Thailand|Thai politics]], providing it with many [[Prime Ministers of Thailand|Prime Ministers]] and carrying out many [[Coup d'état]]s, the [[2014 Thai coup d'état|most recent]] being in 2014.
+
+As of 2013, the Royal Thai Armed Forces had 306,000 active duty personnel.<ref name="GF Active Duty">{{cite web|title=Active Military Manpower by Country|url=http://www.globalfirepower.com/active-military-manpower.asp|website=Global Firepower|publisher=Global Firepower|accessdate=2014-10-16}}</ref> The Thai military has more than 1,750 flag officers (generals and admirals), a bloated number for a military of its size.<ref>{{cite news|last1=Cole|first1=John|last2=Sciacchitano|first2=Steve|title=Thai army: new line-up, same fault-lines|url=http://www.atimes.com/atimes/Southeast_Asia/SEA-01-011013.html|accessdate=4 Apr 2015|work=Asia Times|date=2013-10-01}}</ref> On 2 May 2015  1,043 new flag officers of all three services promoted in 2014-2015 took the oath of allegiance.<ref>{{cite news|title=New generals take oath before the Crown Prince|url=http://thainews.prd.go.th/CenterWeb/NewsEN/NewsDetail?NT01_NewsID=WNROY5805030010001|accessdate=3 May 2015|agency=National News Bureau of Thailand (NNT)|date=2015-05-03}}</ref> It is not clear how many retired during the same period. The [[Monarchy of Thailand|Head of the Thai Armed Forces]] (จอมทัพไทย; {{RTGS|Chom Thap Thai}}) is King [[Bhumibol Adulyadej]] (Rama IX),<ref>[[s:2007 Constitution of Thailand#CHAPTER 2 : THE KING|Chapter 2 of the 2007 Constitution of Thailand]]. En.wikisource.org. Retrieved on 2012-01-18.</ref> however this position is only nominal. The Armed Forces is ostensibly managed by the [[Ministry of Defense (Thailand)|Ministry of Defense of Thailand]], which is headed by the Minister of Defence (a member of the [[Cabinet of Thailand]]) and commanded by the [[Royal Thai Armed Forces Headquarters]], which in turn is headed by the [[List of Commanders of the Royal Thai Armed Forces Headquarters|Chief of Defence Forces of Thailand]].<ref>[http://www.globalsecurity.org/military/world/thailand/mod.htm Ministry of Defense]. www.globalsecurity.org. Retrieved on 2012-01-18.</ref>
+
+According to the [[2007 Constitution of Thailand|Constitution of the Kingdom]], serving in the Armed Forces is a duty of all Thai citizens.<ref>[[s:2007 Constitution of Thailand#CHAPTER 4 : DUTIES OF THE THAI PEOPLE|Chapter 4 of the 2007 Constitution of Thailand]]</ref> However, only males over the age of 21 who have not gone through reserve training are subjected to a random draft. Those chosen randomly are subjected to twenty-four months full-time service, while volunteers are subjected to eighteen months service, depending on their education.
+
+The [[Public holidays in Thailand|Royal Thai Armed Forces Day]] is celebrated on January 18 to commemorate the victory of King [[Naresuan the Great]] in battle against the [[Mingyi Swa|Crown Prince]] of [[Toungoo dynasty|Burma]] in 1593.
+
+==Role==
+The Royal Thai Armed Forces main role is the protection of the [[sovereignty]] and [[territorial integrity]] of the Kingdom of Thailand. The armed forces are also charged with the defence of the [[monarchy of Thailand]] against all threats both foreign and domestic.<ref>[http://web.archive.org/web/20090418003625/http://www.schq.mi.th/EN/vision_mission.htm Vision]. schq.mi.th</ref>
+
+Apart from these roles, the armed forces also have responsibilities ensuring public order and participating in social development programs by aiding the [[Government of Thailand|civilian government]]. The armed forces are also charged with assisting victims of national disasters and drug control.
+
+In recent years the Royal Thai Armed Forces have begun increasing its role on the international stage by providing [[peacekeeping]] forces to the [[United Nations]] (UN), in the [[International Force for East Timor]] (INTERFET), from 1999 to 2002.<ref name="un.org">[http://www.un.org/peace/etimor/UntaetF.htm UNTAET]. Un.org. Retrieved on 2012-01-18.</ref> and participating in the [[multinational force in Iraq]], contributing 423 personnel from 2003 to 2004.<ref name=r1/>
+
+==History==
+{{main|Military history of Thailand}}
+
+===Conflicts===
+The Royal Thai Armed Forces was involved in many conflicts throughout its history, including global, regional and internal conflicts. However, most these were within [[Southeast Asia]]. The only two foreign incursions into Thai territory were in December 1941, when the Empire of [[Japan]] [[Japanese invasion of Thailand|invaded]] and then [[Japanese occupation of Thailand|occupied]] the country, and in the 1980s with [[Vietnam]]ese incursions into Thailand that led to several battles with the Thai Army. Operations on foreign territory were either territorial wars (such as the [[Laos Civil War]]) or conflicts mandated by the [[United Nations]].
+
+*'''[[Franco-Siamese War]]''' (1893)
+*: With the rapid expansion of the [[French Third Republic|French]] [[French colonial empire|Empire]] into [[Indochina]], conflicts necessarily occurred. War became inevitable when a French mission led by [[Auguste Pavie]] to King [[Chulalongkorn]] to try to bring [[Laos]] under French rule ended in failure. The French colonialists invaded Siam from the northeast and sent two warships to fight their way past the river forts and train their guns on the Grand Palace in [[Bangkok]] (the [[Paknam Incident]]). They also declared a blockade of Bangkok, which almost brought them into conflict with the British Navy. Siam was forced to accept the French [[ultimatum]] and surrendered Laos to France, also allowing French troops to occupy the Thai province of [[Chantaburi]] for several decades.<ref>[http://www.nationmultimedia.com/2005/11/02/headlines/data/headlines_19040213.html Legacy of the Paknam clash]. nationmultimedia.com. November 2, 2005</ref>
+
+[[Image:Firstworldwar.jpg|thumb|230px|right|The Siamese Expeditionary Force in Paris, 1919.]]
+*'''[[World War I]]''' (1917–1918)
+*: King [[Vajiravudh]] on the 22 of July 1917 decided to declare war on the [[Central Powers]] and joined the [[Entente Powers]] on the [[Western Front (World War I)|Western Front]]. He sent a volunteer corps, the [[Siam during World War I|Siamese Expeditionary Force]], composed of 1,233 modern-equipped and trained men commanded by Field Marshal Prince [[Chakrabongse Bhuvanath]]. The Force included air and medical personnel, the medical units actually seeing combat. Siam became the only independent [[Asia]]n nation with forces in [[Europe]] during the Great War. Although Siam’s participation militarily was minimal, it enabled the revision or complete cancellation of [[unequal treaties]] with the [[United States]], [[France]] and the [[British Empire]].<ref>[http://www.firstworldwar.com/features/thailand.htm Feature Articles – Thailand and the First World War]. First World War.com (2009-08-22). Retrieved on 2012-01-18.</ref> The Expeditionary Force was given the honour of marching in the victory parade under the [[Arc de Triomphe]] in [[Paris]].<ref>[http://thaimilitary.wordpress.com/2008/11/11/90th-anniversary-of-world-war-i-this-is-the-history-of-siamese-volunteer-crop/ 90th Anniversary of World War I. This Is The History of Siamese Volunteer Crop. « Thai Military Information Blog]. Thaimilitary.wordpress.com (2008-11-11). Retrieved on 2012-01-18.</ref> 19 Siamese soldiers died during the conflict, and their ashes are contained in the World War I monument at the northern end of Bangkok's Pramane Grounds.
+
+*'''[[Franco-Thai War]]''' (1940–1941)
+*:The Franco-Thai War began in October 1940, when the country under the rule of Field Marshal [[Prime Minister of Thailand|Prime Minister]] [[Plaek Phibunsongkhram]] followed up border clashes by invading a French Indo-China, under the [[Vichy France|Vichy regime]] (after the [[Nazi]] occupation of Paris) to regain lost land and settle territorial disputes. The war also bolstered Phibun’s program of promoting Thai nationalism.<ref>[http://www.webcitation.org/query?url=http://www.geocities.com/thailandwwii/nationalism.html&date=2009-10-25+22:47:39 Nation-building and the Pursuit of Nationalism under Field Marshal Plaek Phibunsongkhram]</ref> The war ended indecisively, with Thai victories on land and a naval defeat at sea. However, the disputed territories in French Indochina were ceded to Thailand.
+
+*'''[[World War II]]''' (1942–1945)
+{{main|Thailand in World War II}}
+*:In order to attack [[British India]], [[British Burma]] and [[British Malaya|Malaya]], the Japanese Empire needed to use bases in Thailand. By playing the British Empire against Japan, Prime Minister Phibunsongkhram was able to maintain a degree of neutrality for some time. However, this ended in the early hours of 8 December 1941, when Japan launched a [[Japanese invasion of Thailand|surprise attack]] of Thailand at nine places along the coastline and from French Indo-China. The Thai forces resisted, but were soon being overwhelmed. By 07:30 am, a frightened Phibun ordered an end to hostilities, though resistance continued for another day until all units could be notified. Phibun signed an [[armistice]] with Japan that allowed the Empire to move its troops through Thai territory. After that Thailand became part of the [[Axis powers|Axis]] when Phibun declared war on the United Kingdom and the United States. (The Thai ambassador to Washington refused to deliver the declaration and the United States continued to consider Thailand as an occupied country.) An active and foreign assisted underground resistance movement, the [[Free Thai]], was largely successful and helped Thailand to rehabilitate after the war and be treated as a friendly rather than an enemy nation.<ref>[http://lcweb2.loc.gov/cgi-bin/query/r?frd/cstdy:@field(DOCID+th0031) Thailand]. Lcweb2.loc.gov (1941-12-08). Retrieved on 2012-01-18.</ref><ref>[http://www.insigne.org/OSS-Thai.htm Free Thai]. Insigne.org. Retrieved on 2012-01-18.</ref>
+
+*'''[[Korean War]]''' (1950–1953)
+*: During the United Nations-mandated conflict in the [[Korean peninsula]], Thailand provided the 21st Regiment of about 1,294 men. The Kingdom also provided 4 naval vessels and an air transport unit to the UN command structure. The contingent was actively engaged and suffered heavy casualties, including 139 dead. They returned to Thailand in 1955.<ref>[http://web.archive.org/web/20070716130959/http://korea50.army.mil/history/factsheets/allied.shtml Factsheet]. korea50.army.mil</ref>
+
+[[Image:Thai Soldiers Board C-130 at Long Thanh for Trip Home.jpg|thumb|210px|right|Thai soldiers boarding a [[USAF]] aircraft, during the Vietnam War.]]
+*'''[[Vietnam War]]''' (1955–1975)
+*: Due to its close proximity with Thailand, [[Vietnam]]'s conflict was closely monitored by Bangkok. Thai involvement did not become official until the [[Gulf of Tonkin Resolution|total involvement]] of the [[United States]] in 1963. Thailand allowed the [[United States Air Force in Thailand]] to use air bases and naval bases for U.S. forces. Eventually contributing infantry units and other resources. The Thai Armed Forces suffered 1,351 deaths. However, Thailand was more involved with the [[Laotian Civil War|Secret War]] and covert operations in Laos from 1964 to 1972. By 1975 relations between Bangkok and Washington had soured, and in 1977 President [[James Earl Carter]] withdrew all U.S. military personnel and the bases were closed.
+
+*'''[[Communist Party of Thailand|Communist Insurgency]]''' (1976-1980s)
+*: The [[Communist]] victory in Vietnam in 1975 emboldened the Communist movement within Thailand, which has been in existence since the 1920s. After the [[6 October 1976 Massacre|Thammasat University massacre of leftist student demonstrators in 1976]] and the repressive policies of rightwing Prime Minister [[Tanin Kraivixien]], sympathies for the movement increased. By the late seventies it is estimated that the movement had as many as 12,000 armed insurgents,<ref>[http://www.onwar.com/aced/chrono/c1900s/yr55/fthailand1959.htm Thailand Communist Insurgency 1959–Present]. Onwar.com. Retrieved on 2012-01-18.</ref> mostly based in the northeast along the Laotian border. By the 1980s, however, all insurgent activities had been defeated. In 1982 Prime Minister [[Prem Tinsulanonda]] issued a general amnesty for all Communist former insurgents.
+
+*'''[[Vietnamese border raids in Thailand|Vietnamese border raids]]''' (1979–1988)
+*: With the Vietnamese [[Cambodian–Vietnamese War|invasion of Cambodia]] in 1978, Communist Vietnam had a combined force of about 300,000 in Laos and Cambodia. This posed a massive potential threat to the Thais, as they could no longer rely on Cambodia to act as a [[buffer state]]. Small encounters occasionally took place when Vietnamese forces crossed into Thailand in pursuit of fleeing [[Khmer Rouge]] troops. However, a full and official conflict was never declared, as neither country wanted it.
+
+*'''[[Thai–Laotian Border War]]''' (1987–1988)
+*: This was a small conflict over mountainous territory including three disputed villages on the border between the [[Sainyabuli Province]] in Laos and [[Phitsanulok Province]] in Thailand, whose ownership had been left unclear by the map drawn by the French some 80 years earlier. Caused by then Army commander [[Chavalit Yongchaiydht]] against the wishes of the government, the war ended with a virtual Laos' surrender{{Citation needed|date=March 2013}} and return to [[status quo ante bellum]]. The two nations suffered combined casualties of about 1,000.<ref>[http://www.historyguy.com/thai_laos_border_war_87.html Thailand-Laos Border War 1987–1988]. The History Guy. Retrieved on 2012-01-18.</ref>
+
+*'''[[United Nations Transitional Administration in East Timor|East Timor]]''' (1999–2002)
+*: After the [[1999 East Timorese crisis|East Timor Crisis]], Thailand with 28 other nations provided troops for the  [[International Force for East Timor|International Force for East Timor or INTERFET]]. Thailand also provided the Force Commander, Lieutenant General Winai Phattiyakul.<ref name="un.org"/> The force was based in [[Dili]] and lasted from 25 October 1999 to 20 May 2002.
+
+[[Image:US Army instructs Thai Army 2001.jpg|thumb|210px|right|Thai and U.S. military training together during [[Cobra Gold]] 2001.]]
+*'''[[Iraq War]]''' (2003–2004)
+*: After the [[2003 invasion of Iraq|successful U.S. invasion of Iraq]], Thailand contributed 423 non-combat troops in August 2003 to nation building and medical assistance in [[Coalition Provisional Authority|post-Saddam Iraq]].<ref>[http://web.archive.org/web/20090421011422/http://www.asiantribune.com/oldsite/show_news.php?id=9283 Thailand to withdraw troops from Iraq if attacked]. Asian Tribune (2004-04-21).</ref> Troops of the Royal Thai Army were attacked in the [[2003 Karbala bombings]], which killed 2 soldiers and wounded 5 others.<ref>[http://www.cnn.com/2003/WORLD/meast/12/27/sprj.irq.main/index.html Karbala attacks kill 12, wound dozens]. CNN (2003-12-27). Retrieved on 2012-01-18.</ref> However, the Thai mission in Iraq was considered successful, and Thailand withdrew its forces in August 2004. The mission is considered the main reason the United States decided to designate Thailand as a [[Major non-NATO ally]] in 2003.<ref name=r1>[http://web.archive.org/web/20090825111721/http://www.centcom.mil/en/countries/coalition/thailand/ Thailand]. centcom.mil</ref>
+
+*'''[[South Thailand insurgency|Southern insurgency]]''' (2004–ongoing)
+*: The ongoing Southern insurgency began long before 2004, waged by the ethnic [[Malay (ethnic group)|Malay]]s and [[Patani United Liberation Organisation|Islamic rebels]] in the three southern provinces of [[Yala Province|Yala]], [[Pattani Province|Pattani]] and [[Narathiwat Province|Narathiwat]], but it had always been small scale. The insurgency intensified in 2004, when terrorist attacks were extended to ethnic Thai civilians in the provinces.<ref>[http://www.iht.com/articles/ap/2007/06/14/asia/AS-GEN-Thailand-Southern-Violence.php Search – Global Edition – The New York Times]. International Herald Tribune (2009-03-29). Retrieved on 2012-01-18.</ref> The Royal Thai Armed Forces in turn responded with heavy armed tactics.<ref>[http://www.janes.com/news/security/countryrisk/jiaa/jiaa071119_1_n.shtml Thailand's counter-insurgency operations]. Janes.com (2007-11-19). Retrieved on 2012-01-18.</ref> By the end of 2012 the conflict had claimed 3,380 lives, including 2,316 civilians, 372 soldiers, 278 police, 250 suspected insurgents, 157 education officials and seven Buddhist monks. The insurgents have extended their attacks to ethnic Malay Thai Muslims who do not support them.<ref>Data from the (governmental) Southern Border Provinces Administrative Centre, cited in [http://www.isranews.org/south-news/scoop/item/18593.html ISRANews] report, 4 January 2013</ref>
+
+*'''[[Cambodian–Thai border stand-off]]''' (2008-2011)
+
+*'''[[United Nations Mission in Sudan|Sudan]]''' (2010-2011)
+
+*'''[[United Nations Assistance Mission in Afghanistan|Afghanistan]]''' (2012)
+
+== Current developments ==
+[[File:Royal Thai Army soldiers in woods 2006.jpg|thumb|260px|Thai and U.S. Army Soldiers practice tactical maneuvers during exercise [[Cobra Gold]] 2006 in [[Lop Buri]].]]
+[[File:Chakri Naruebet 2001.JPEG|thumb|[[HTMS Chakri Naruebet]]]]
+[[File:RTAF Jas 39 Gripen.jpg|thumb|[[JAS-39 Gripen|Saab JAS 39 Gripen]] of the Royal Thai Air Force.]]
+
+===Royal Thai Navy===
+{{Main|Royal Thai Navy}}
+The navy's combat forces included the Royal Fleet and the Royal Thai Marine Corps. The 130 vessels of the Royal Fleet included frigates equipped with surface-to-air missiles, fast attack craft armed with surface-to-surface missiles, large coastal patrol craft, coastal minelayers, coastal minesweepers, landing craft, and training ships.
+
+The mission spaces of Thailand navy include the Thai Gulf and Indian Ocean, separated by land, and river. Naval affairs were directed by the country's most senior admiral from his Bangkok headquarters. The naval commander in chief was supported by staff groups that planned and administered such activities as logistics, education and training, and various special services. The headquarters general staff functioned like those of corresponding staffs in the army and air force command structures.
+
+==Weapons and equipment==
+
+{| class="wikitable"
+|-
+!Equipment<ref name="INSS">[The Institute for National Security Studies", chapter Israel, 2008] March 23, 2008.</ref>
+!Quantity!!In Service!!On Order
+|-
+|[[Main Battle Tank]] and [[Light Tank]] ||align=center| 788 ||align=center| 788 ||align=center| 200
+|-
+|[[Armoured personnel carrier|APCs]], [[Infantry fighting vehicle|IFVs]], [[Armoured recovery vehicle|ARVs]], [[Landing craft|LCV]]s ||align=center| 1233 ||align=center| 1233 ||align=center| 217+6
+|-
+|[[Self-propelled artillery]] ||align=center| 1072 ||align=center| 1072 ||align=center| 60
+|-
+|Combat [[warplane]]s ||align=center| 171+AV8 ||align=center| 168 ||align=center| 12
+|-
+|Transport [[warplane]]s ||align=center| 114 ||align=center| 114 ||align=center| 0
+|-
+|Training [[warplane]]s ||align=center| 56 ||align=center| 55 ||align=center| 0
+|-
+|[[Military helicopter]]s ||align=center| 282 ||align=center| 282 ||align=center| 25
+|-
+|[[aircraft carrier]] batteries ||align=center| 1 ||align=center| 1 ||align=center| 0
+|-
+|[[Warship]]s ||align=center| 17 ||align=center| 17 ||align=center| 2     LPD
+|-
+|[[Missile boat|Fast Attack Craft-Missile (FAC-M)]]s ||align=center| 6 ||align=center| 6 ||align=center| 6
+|-
+|[[submarine]] ||align=center| 0 ||align=center| 0 ||align=center| 0
+|-
+|[[Patrol boat]]s ||align=center| 127 ||align=center| 127 ||align=center| 2
+|}
+
+==Uniforms, ranks, insignia==
+To build institutional solidarity and esprit de corps, each Thai service component has developed its own distinctive uniforms, ranking system, and insignia.<ref>[http://lcweb2.loc.gov/cgi-bin/query/r?frd/cstdy:@field%28DOCID+th0148%29 Thailand]. Lcweb2.loc.gov. Retrieved on 2012-01-18.</ref> Many Thai military uniforms reflect historical foreign influences. For example, most of the distinctive service uniforms were patterned on those of the US, but lower ranking enlisted navy personnel wear uniforms resembling those of their French counterparts. The early influence of British advisers to the Thai royal court and the historical role of the military in royal pomp and ceremony contributed to the splendor of formal dress uniforms worn by high-ranking officers and guards of honor on ceremonial occasions.
+
+[[File:The 1st Artillery Bataillion, King's Guard in the procession of Princess Galyani Vadhana's royal urn.jpg|thumb|260px|The 1st Artillery Battalion, King's Guard in the procession of Princess [[Galyani Vadhana]]'s royal urn]]
+
+The rank structures of the three armed services are similar to those of the respective branches of the US Armed Forces, although the Thai system has fewer NCO and warrant officer designations. The king, as head of state and constitutional head of the armed forces, commissions all officers. Appointments to NCO ranks are authorized by the minister of defense. In theory, the authority and responsibilities of officers of various ranks correspond to those of their US counterparts. However, because of a perennial surplus of senior officers—in 1987 there were some 600 generals and admirals in a total force of about 273,000—Thai staff positions are often held by officers of higher rank than would be the case in the US or other Western military establishments.
+
+Thai military personnel are highly conscious of rank distinctions and of the duties, obligations, and benefits they entail. Relationships among officers of different grades and among officers, NCOs, and the enlisted ranks are governed by military tradition in a society where observance of differences in status are highly formalized. The social distance between officers and NCOs is widened by the fact that officers usually are college or military academy graduates, while most NCOs have not gone beyond secondary school. There is a wider gap between officers and conscripts, most of whom have even less formal education, service experience, or specialized training.
+
+Formal honors and symbols of merit occupy an important place in Thai military tradition. The government grants numerous awards, and outstanding acts of heroism, courage, and meritorious service receive prompt recognition.
+
+== Gallery ==
+<gallery>
+File:2010 0513 silom 11.JPG|Soldiers with riot shields at a barricade on Silom Rd and Soi Convent.
+File:2010 0513 saladaeng station 02.JPG|Soldiers underneath Saladaeng BTS station on Silom Rd.
+File:2010 0513 silom 24.JPG|Two soldiers eat rice and fish cakes provided free of charge by a "yellow shirt" street vendor, possible evidence of the relationship between the Yellow Shirts (PAD) and the Thai military.
+File:2010 0513 silom 07.JPG|Soldiers and a helmeted journalist buy water and food at a convenience store on Silom Rd.
+File:2010 0513 silom 23.JPG|Soldiers using civilian motorbikes to quickly get from one place to another on Silom Rd. "Red shirt" taxi drivers had  encircled that part of Silom Rd, from Narathiwat intersection to Rama 4 intersection.
+File:2010 0519 Chiang Mai unrest 14.JPG|Soldiers and Royal Thai Police stand guard on the west side of Chiang Mai's Nawarat Bridge facing onlookers and "red shirts" after protesters had started fires at the residence of the governor of Chiang Mai and on both sides of Nawarat Bridge.
+File:2014 0526 Thailand coup Chang Phueak Gate Chiang Mai 02.jpg|Thai military at Chang Phueak Gate in Chiang Mai, days after the [[2014 Thai coup d'état]]
+</gallery>
+
+==See also==
+*[[Thahan Phran]]
+*[[Army Reserve Force Students]]
+*[[Royal Guards (Thailand)]]
+* [[Royal Thai Air Force]]
+* [[Royal Thai Navy SEALs]]
+* [[Border Patrol Police]]
+* [[Military ranks of the Thai armed forces]]
+*[[Flags of the Royal Thai Armed Forces]]
+* [[Royal Thai Police]]
+
+==References==
+{{loc}}
+{{reflist|35em}}
+
+==Further reading==
+* Osornprasop, Sutayut. "Thailand and the Secret War in Laos", 1960-1974 (in) Albert Lau (ed.), ''Southeast Asia and the Cold War''. Milton Park, Abingdon, Oxon; New York, NY: Routledge, 2012. ISBN 9780415684507 (hardback).
+
+== External links ==
+{{commons category|Military of Thailand}}
+* [http://www.rtarf.mi.th/index_new.html Official website of Royal Thai Armed Forces Headquarters]
+* [http://www.rta.mi.th Official website of Royal Thai Army]
+* [http://www.navy.mi.th Official website of Royal Thai Navy]
+* [http://www.rtaf.mi.th Official website of Royal Thai Air Forces]
+* "[http://www.atimes.com/atimes/Southeast_Asia/KI02Ae01.html Religion, guns tear apart south Thailand]" – (September 2, 2009) article in ''[[Asia Times Online]]'' giving an overview of the Thai army's use of paramilitary forces.
+
+{{Military of Thailand}}
+{{Government of Thailand|state=collapsed}}
+{{Thailand topics}}
+{{Association of SouthEast Asian Nations Armed Forces}}
+{{Military of Asia}}
+
+[[Category:Military of Thailand|!]]
+[[Category:Military units and formations established in 1852]]
+[[Category:1852 establishments in Siam]]
+
+[[bn:থাইল্যান্ডের সামরিক বাহিনী]]


### PR DESCRIPTION
Fixes Issue https://github.com/diegoceccarelli/json-wikipedia/issues/5

- When descriptions are empty it uses the wikipedia Id replacing underscores by spaces.