### PR TITLE
Update dependency to fix build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>info.bliki.wiki</groupId>
 			<artifactId>bliki-core</artifactId>
-			<version>3.1.0-SNAPSHOT</version>
+			<version>3.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>xerces</groupId>


### PR DESCRIPTION
the command, 'mvn assembly:assembly' causes build failure,

updating current 'bliki-core' version (3.1.0-SNAPSHOT)  to 3.1.0 will solve this problem.
