### PR TITLE
Snapshot of bliki-core 3.1.0 issue.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>info.bliki.wiki</groupId>
 			<artifactId>bliki-core</artifactId>
-			<version>3.1.0-SNAPSHOT</version>
+			<version>3.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>xerces</groupId>


### PR DESCRIPTION
The snapshot is no longer available on maven so the base 3.1.0 version must be used.