### PR TITLE
ISSUE 41 # update de.tudarmstadt.ukp.wikipedia version numbers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,11 +157,18 @@
                         <url>https://jitpack.io</url>
                     </repository>
         <repository>
-            <id>ossrh</id>
+            <id>ossrh-snapshot</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<snapshots><enabled>true</enabled></snapshots>
         </repository>
-                </repositories>
+
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
+
+
+    </repositories>
                 <build>
                     <!-- <extensions>
                                     <extension>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,6 @@
         <repository>
             <id>ossrh</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
         </repository>
                 </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,9 @@
                     </repository>
         <repository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<releases><enabled>false</enabled></releases>
+			<snapshots><enabled>true</enabled></snapshots>
         </repository>
                 </repositories>
                 <build>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 				<artifactId>de.tudarmstadt.ukp.wikipedia</artifactId>
-				<version>1.2.0-SNAPSHOT</version>
+				<version>1.1.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -72,27 +72,27 @@
 		<dependency>
 			<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 			<artifactId>de.tudarmstadt.ukp.wikipedia.api</artifactId>
-			<version>1.2.0-SNAPSHOT</version>
+			<version>1.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 			<artifactId>de.tudarmstadt.ukp.wikipedia.parser</artifactId>
-			<version>1.2.0-SNAPSHOT</version>
+			<version>1.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 			<artifactId>de.tudarmstadt.ukp.wikipedia.datamachine</artifactId>
-			<version>1.2.0-SNAPSHOT</version>
+			<version>1.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 			<artifactId>de.tudarmstadt.ukp.wikipedia.revisionmachine</artifactId>
-			<version>1.2.0-SNAPSHOT</version>
+			<version>1.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 			<artifactId>de.tudarmstadt.ukp.wikipedia.timemachine</artifactId>
-			<version>1.2.0-SNAPSHOT</version>
+			<version>1.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
@@ -209,8 +209,8 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
                             <encoding>${project.source.encoding}</encoding>
-                            <source>${java.version.source}</source>
-                            <target>${java.version.target}</target>
+							<source>${java.version.source}</source>
+							<target>${java.version.target}</target>
                         </configuration>
                         <version>3.3</version>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 				<artifactId>de.tudarmstadt.ukp.wikipedia</artifactId>
-				<version>1.1.0</version>
+				<version>1.2.0-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -72,27 +72,27 @@
 		<dependency>
 			<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 			<artifactId>de.tudarmstadt.ukp.wikipedia.api</artifactId>
-			<version>1.1.0</version>
+			<version>1.2.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 			<artifactId>de.tudarmstadt.ukp.wikipedia.parser</artifactId>
-			<version>1.1.0</version>
+			<version>1.2.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 			<artifactId>de.tudarmstadt.ukp.wikipedia.datamachine</artifactId>
-			<version>1.1.0</version>
+			<version>1.2.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 			<artifactId>de.tudarmstadt.ukp.wikipedia.revisionmachine</artifactId>
-			<version>1.1.0</version>
+			<version>1.2.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 			<artifactId>de.tudarmstadt.ukp.wikipedia.timemachine</artifactId>
-			<version>1.1.0</version>
+			<version>1.2.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
@@ -209,8 +209,8 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
                             <encoding>${project.source.encoding}</encoding>
-							<source>${java.version.source}</source>
-							<target>${java.version.target}</target>
+                            <source>${java.version.source}</source>
+                            <target>${java.version.target}</target>
                         </configuration>
                         <version>3.3</version>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
 		<repository>
 			<id>ossrh</id>
 			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 
 


### PR DESCRIPTION
I took a look at maven repository and also https://oss.sonatype.org/service/local/staging/deploy/maven2/ repository and found out that there was no 1.2.0-SNAPSHOT version number which I could find of. 1.1.0 version number was present in mutiple places so I changed  it to that version. Warnings now are gone. I also ran test and everything is working fine.