### PR TITLE
Remove 'thread' option from CLI (not used)

### DIFF
--- a/src/main/java/it/cnr/isti/hpc/wikipedia/cli/MediawikiToJsonCLI.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/cli/MediawikiToJsonCLI.java
@@ -71,7 +71,7 @@ public class MediawikiToJsonCLI extends AbstractCommandLineInterface {
   /** Logger for this class */
   private static final Logger logger = LoggerFactory.getLogger(MediawikiToJsonCLI.class);
 
-  private static String[] params = new String[] {INPUT, OUTPUT, "lang", "threads"};
+  private static String[] params = new String[] {INPUT, OUTPUT, "lang"};
 
   private static final String USAGE =
       "java -cp $jar "


### PR DESCRIPTION
The main cli has a parameter thread that it is not used (it will fail running the CLI) 