### PR TITLE
Use UTF8 encoding when running the CLI

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -5,7 +5,7 @@ XMX="-Xmx8000m"
 LOG=INFO
 ##LOG=DEBUG
 LOGAT=1000
-JAVA="java $XMX -Dlogat=$LOGAT -Dlog=$LOG -Dlogback.configurationFile=./logback.xml -cp ./target/json-wikipedia-$VERSION-jar-with-dependencies.jar "
+JAVA="java $XMX -Dlogat=$LOGAT  -Dfile.encoding=UTF-8 -Dlog=$LOG -Dlogback.configurationFile=./logback.xml -cp ./target/json-wikipedia-$VERSION-jar-with-dependencies.jar "
 
 
 


### PR DESCRIPTION
Set UTF8 default encoding when running the cli, this is needed mainly for avro, the avro writer will use the encoding setup in the environment. 