### PR TITLE
Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,13 +143,6 @@
 			<version>4.6.1</version>
 		</dependency>
 	</dependencies>
-	<!-- repositories> <repository> <id>lilyproject</id> <url>http://www.lilyproject.org/maven/maven2/deploy/</url> 
-		<releases> <enabled>true</enabled> </releases> <snapshots> <enabled>false</enabled> 
-		</snapshots> </repository> <repository> <id>info-bliki-repository</id> <url>http://gwtwiki.googlecode.com/svn/maven-repository/</url> 
-		<releases> <enabled>true</enabled> </releases> <snapshots> <enabled>false</enabled> 
-		</snapshots> </repository> <repository> <id>ontotext</id> <url>http://maven.ontotext.com/content/repositories/public/</url> 
-		<releases> <enabled>true</enabled> </releases> <snapshots> <enabled>false</enabled> 
-		</snapshots> </repository> </repositories -->
 	<repositories>
 		<repository>
 			<id>sonatype-snapshots</id>
@@ -157,7 +150,7 @@
 		</repository>
 		<repository>
 			<id>de.tudarmstadt.ukp.wikipedia</id>
-			<url>http://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-snapshots/</url>
+			<url>https://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-snapshots/</url>
 			<snapshots>
 				<enabled>true</enabled>
 				<updatePolicy>always</updatePolicy>


### PR DESCRIPTION
Otherwise current versions of maven will refuse to install the dependency